### PR TITLE
#177 - Rename Entry.customProperties to extendedProps in JSON

### DIFF
--- a/addon/src/main/java/org/vaadin/stefan/fullcalendar/Entry.java
+++ b/addon/src/main/java/org/vaadin/stefan/fullcalendar/Entry.java
@@ -98,6 +98,7 @@ public class Entry {
 
     private Set<String> classNames;
 
+    @JsonName("extendedProps")
     private Map<String, Object> customProperties;
 
     @JsonIgnore


### PR DESCRIPTION
Sorry if I should have asked first whether there's a reason for naming it customProperties, but it seemed like a quick thing and no harm done if the PR is rejected. All this does is rename customProperties to extendedProps, which is what FC expects for non-standard fields (https://fullcalendar.io/docs/event-object).

I ran into a similar issue to what was mentioned in #177 where I wasn't able to order calendar entries by a custom property, even though FC docs say it is possible (https://fullcalendar.io/docs/eventOrder):

>This setting accepts a few different arguments:
>
>* a name of an [Event Object](https://fullcalendar.io/docs/event-object) property, like "title". This can be the name of a non-standard field.

It might be because the custom property is getting nested an extra level (extendedProps -> customProperties -> property). FC is probably moving customProperties into the extendedProps hash:

>Any non-standard properites are moved into the extendedProps hash during [event parsing](https://fullcalendar.io/docs/event-parsing).

If this isn't acceptable, I may have time to modify this to enable setting an eventOrder function (which was also mentioned on #177 as a possible solution), but this seemed like the easiest solution.